### PR TITLE
Change/remove-maven-uri-create

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ gradlePlugin {
     website.set("https://github.com/EyadAbdullah/gradle-repository-manager")
     vcsUrl.set("https://github.com/EyadAbdullah/gradle-repository-manager")
     plugins {
-        create("gradle-repository-manager") {
+        register("gradle-repository-manager") {
             id = "io.github.eyadabdullah.gradle-repository-manager"
             implementationClass = "io.github.eyadabdullah.gradlerepositorymanager.RepositoryManagerPlugin"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/io/github/eyadabdullah/gradlerepositorymanager/RepositoryManagerService.java
+++ b/src/main/java/io/github/eyadabdullah/gradlerepositorymanager/RepositoryManagerService.java
@@ -3,7 +3,6 @@ package io.github.eyadabdullah.gradlerepositorymanager;
 import io.github.eyadabdullah.gradlerepositorymanager.exceptions.MissingRepositoryCredentials;
 import io.github.eyadabdullah.gradlerepositorymanager.extension.ManageableRepository;
 import io.github.eyadabdullah.gradlerepositorymanager.extension.RepositoryManagerExtension;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -40,7 +39,6 @@ public class RepositoryManagerService {
   /**
    * We are surpassing UnstableApiUsage as the systemPropertiesPrefixedBy feature is still a work in progress and my change in the future.
    */
-  @SuppressWarnings("UnstableApiUsage")
   public void findRepositoryCredentialsFromGradleProperties(ProviderFactory provider) {
     var repositoryCredentialsToConfigure = new HashMap<String, RepositoryCredentials>();
     var repositorySystemProperties = provider.systemPropertiesPrefixedBy(REPOSITORY_DEFINITION_PREFIX).get();
@@ -81,7 +79,7 @@ public class RepositoryManagerService {
     repoHandler.maven(mavenArtifactRepository -> {
       // set repo information
       mavenArtifactRepository.setName(repository.getName());
-      mavenArtifactRepository.setUrl(URI.create(repository.getUrl()));
+      mavenArtifactRepository.setUrl(repository.getUrl());
       mavenArtifactRepository.setAllowInsecureProtocol(!repository.isSecureProtocol());
 
       if (repository.isSnapshotsOnly()) {


### PR DESCRIPTION
Removing URI.create enables additional capabilities, such as loading local URLs from file system paths, etc.